### PR TITLE
Allow the Datadog Tracer to be configured

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,43 @@
+package ddtracer
+
+import (
+	"io"
+
+	"github.com/DataDog/dd-trace-go/tracer"
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+// Configuration is used to define DataDog Tracer properties to be set when creating a new tracer
+type Configuration struct {
+	SampleRate          float64 // Sample rate for collecting spans (0-1)
+	SpansBufferSize     int     // Buffer size for storing spans (default: 10000)
+	DebugLoggingEnabled bool    // Enable or Disable DebugLogging (default: false)
+	Enabled             bool    // Enable or Disable the tracer (default: false)
+}
+
+func (c *Configuration) NewTracer() (opentracing.Tracer, io.Closer) {
+	return c.NewTracerTransport(nil)
+}
+
+func (c *Configuration) NewTracerTransport(transport tracer.Transport) (opentracing.Tracer, io.Closer) {
+	var driver *tracer.Tracer
+	if transport == nil {
+		driver = tracer.NewTracer()
+	} else {
+		driver = tracer.NewTracerTransport(transport)
+	}
+
+	t := &Tracer{Tracer: driver}
+	t.textPropagator = &textMapPropagator{t}
+
+	t.Tracer.SetEnabled(c.Enabled)
+	t.Tracer.DebugLoggingEnabled = c.DebugLoggingEnabled
+
+	t.Tracer.SetSampleRate(c.SampleRate)
+	if c.SpansBufferSize > 0 {
+		t.Tracer.SetSpansBufferSize(c.SpansBufferSize)
+	}
+
+	// return the tracer as a closer so it can be cleaned up
+	return t, t
+}

--- a/tracing.go
+++ b/tracing.go
@@ -116,6 +116,12 @@ func (t *Tracer) Extract(format interface{}, carrier interface{}) (opentracing.S
 	return nil, opentracing.ErrUnsupportedFormat
 }
 
+func (t *Tracer) Close() error {
+	t.Stop()
+	t.Tracer.Stop()
+	return nil
+}
+
 type Span struct {
 	*tracer.Span
 	tracer *Tracer


### PR DESCRIPTION
This PR adds 2 simple pieces of functionality. 

The first is to make the tracer satisfy the io.Closer interface that way traces can be safely cleaned up during run time. 

The second is to add a Configuration object to the tracer so that the underlying Datadog tracer can be configured.